### PR TITLE
Add TraceLife 3D beverage showcase

### DIFF
--- a/tracelife-site/index.html
+++ b/tracelife-site/index.html
@@ -4,12 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TraceLife Premium Beverages</title>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <script type="module" src="script.js"></script>
 </head>
 <body>
-  <header>
-    <h1>TraceLife Premium Beverages</h1>
+  <header class="hero">
+    <h1>TraceLife</h1>
+    <p>Premium beverages in vivid 3D</p>
   </header>
   <main id="gallery">
     <div class="can" id="can1"></div>

--- a/tracelife-site/index.html
+++ b/tracelife-site/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>TraceLife Premium Beverages</title>
+  <link rel="stylesheet" href="style.css">
+  <script type="module" src="script.js"></script>
+</head>
+<body>
+  <header>
+    <h1>TraceLife Premium Beverages</h1>
+  </header>
+  <main id="gallery">
+    <div class="can" id="can1"></div>
+    <div class="can" id="can2"></div>
+    <div class="can" id="can3"></div>
+    <div class="can" id="can4"></div>
+    <div class="can" id="can5"></div>
+  </main>
+  <footer>
+    <p>© 2025 TraceLife</p>
+  </footer>
+</body>
+</html>

--- a/tracelife-site/script.js
+++ b/tracelife-site/script.js
@@ -13,7 +13,11 @@ function init(container, color) {
   scene.add(light);
 
   const geometry = new THREE.CylinderGeometry(1, 1, 2, 64);
-  const material = new THREE.MeshStandardMaterial({ color });
+  const material = new THREE.MeshPhysicalMaterial({
+    color,
+    metalness: 0.3,
+    roughness: 0.3
+  });
   const can = new THREE.Mesh(geometry, material);
   scene.add(can);
 
@@ -22,6 +26,7 @@ function init(container, color) {
 
   function animate() {
     requestAnimationFrame(animate);
+    can.rotation.y += 0.01;
     renderer.render(scene, camera);
   }
 

--- a/tracelife-site/script.js
+++ b/tracelife-site/script.js
@@ -1,0 +1,40 @@
+import * as THREE from 'https://unpkg.com/three@0.158.0/build/three.module.js';
+import { OrbitControls } from 'https://unpkg.com/three@0.158.0/examples/jsm/controls/OrbitControls.js';
+
+function init(container, color) {
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(50, container.clientWidth / container.clientHeight, 0.1, 1000);
+  const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+  renderer.setSize(container.clientWidth, container.clientHeight);
+  container.appendChild(renderer.domElement);
+
+  const light = new THREE.DirectionalLight(0xffffff, 1);
+  light.position.set(1, 1, 1).normalize();
+  scene.add(light);
+
+  const geometry = new THREE.CylinderGeometry(1, 1, 2, 64);
+  const material = new THREE.MeshStandardMaterial({ color });
+  const can = new THREE.Mesh(geometry, material);
+  scene.add(can);
+
+  const controls = new OrbitControls(camera, renderer.domElement);
+  camera.position.z = 4;
+
+  function animate() {
+    requestAnimationFrame(animate);
+    renderer.render(scene, camera);
+  }
+
+  animate();
+
+  window.addEventListener('resize', () => {
+    camera.aspect = container.clientWidth / container.clientHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(container.clientWidth, container.clientHeight);
+  });
+}
+
+const colors = ['#a1d2ff', '#ff9393', '#c6ffa1', '#fff1a1', '#d1a1ff'];
+['can1', 'can2', 'can3', 'can4', 'can5'].forEach((id, i) => {
+  init(document.getElementById(id), colors[i]);
+});

--- a/tracelife-site/style.css
+++ b/tracelife-site/style.css
@@ -1,0 +1,31 @@
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  color: #333;
+  background-color: #fdfdfd;
+}
+header, footer {
+  text-align: center;
+  padding: 1rem;
+  background-color: #111;
+  color: #fff;
+}
+#gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  padding: 1rem;
+}
+.can {
+  width: 100%;
+  height: 300px;
+  background-color: #eaeaea;
+}
+@media (min-width: 600px) {
+  .can {
+    height: 400px;
+  }
+}

--- a/tracelife-site/style.css
+++ b/tracelife-site/style.css
@@ -3,26 +3,33 @@
 }
 body {
   margin: 0;
-  font-family: Arial, sans-serif;
+  font-family: 'Roboto', Arial, sans-serif;
   color: #333;
-  background-color: #fdfdfd;
+  background: linear-gradient(#ffffff, #f0f0f0);
 }
-header, footer {
+.hero {
+  background: #111;
+  color: #fff;
+  text-align: center;
+  padding: 2rem 1rem;
+}
+footer {
   text-align: center;
   padding: 1rem;
-  background-color: #111;
+  background: #111;
   color: #fff;
 }
 #gallery {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
-  padding: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 2rem;
+  padding: 2rem;
 }
 .can {
   width: 100%;
   height: 300px;
   background-color: #eaeaea;
+  border-radius: 8px;
 }
 @media (min-width: 600px) {
   .can {


### PR DESCRIPTION
## Summary
- add minimal website showing TraceLife beverage cans as 3D models

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685d26700bc48320868ac98193313ab0